### PR TITLE
Fix: 修复 CalDAV 全天事件的 datetime 类型不匹配问题

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -75,3 +75,7 @@ CLAUDE.md
 
 # Claude Desktop and MCP configurations (if containing personal data)
 claude_desktop_config.json
+
+# OpenSpec - specifications and change management
+openspec/
+.openspec/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,18 @@
+<!-- OPENSPEC:START -->
+# OpenSpec Instructions
+
+These instructions are for AI assistants working in this project.
+
+Always open `@/openspec/AGENTS.md` when the request:
+- Mentions planning or proposals (words like proposal, spec, change, plan)
+- Introduces new capabilities, breaking changes, architecture shifts, or big performance/security work
+- Sounds ambiguous and you need the authoritative spec before coding
+
+Use `@/openspec/AGENTS.md` to learn:
+- How to create and apply change proposals
+- Spec format and conventions
+- Project structure and guidelines
+
+Keep this managed block so 'openspec update' can refresh the instructions.
+
+<!-- OPENSPEC:END -->

--- a/mcp_ical/models.py
+++ b/mcp_ical/models.py
@@ -20,7 +20,7 @@ Pydantic 请求模型（CreateEventRequest, UpdateEventRequest）。
 
 import re
 from dataclasses import dataclass
-from datetime import datetime
+from datetime import datetime, date
 from enum import IntEnum
 from typing import Annotated, Self, Optional
 
@@ -280,7 +280,15 @@ class Event:
         title = getattr(vevent, 'summary', '').value if hasattr(vevent, 'summary') and vevent.summary else 'No Title'
         start_time = getattr(vevent, 'dtstart', '').value if hasattr(vevent, 'dtstart') and vevent.dtstart else None
         end_time = getattr(vevent, 'dtend', '').value if hasattr(vevent, 'dtend') and vevent.dtend else None
-        
+
+        # Handle all-day events: convert date objects to datetime objects
+        # For all-day events, CalDAV returns date objects instead of datetime objects
+        # We need to convert them to datetime to maintain type consistency
+        if isinstance(start_time, date) and not isinstance(start_time, datetime):
+            start_time = datetime.combine(start_time, datetime.min.time())
+        if isinstance(end_time, date) and not isinstance(end_time, datetime):
+            end_time = datetime.combine(end_time, datetime.min.time())
+
         # 统一时区: 将所有带时区的 datetime 转换为 naive datetime
         if start_time and hasattr(start_time, 'tzinfo') and start_time.tzinfo:
             start_time = start_time.replace(tzinfo=None)

--- a/test_calendar_manager_integration.py
+++ b/test_calendar_manager_integration.py
@@ -3,8 +3,8 @@ from datetime import datetime, timedelta
 
 import pytest
 
-from src.mcp_ical.ical import CalendarManager, NoSuchCalendarException
-from src.mcp_ical.models import (
+from mcp_ical.ical import CalendarManager, NoSuchCalendarException
+from mcp_ical.models import (
     CreateEventRequest,
     Frequency,
     RecurrenceRule,


### PR DESCRIPTION
- CalDAV 全天事件的 start_time 可能是 datetime.date 类型而不是 datetime.datetime 类型
- 修复 web_client/app.py:622 中 original_start <= e.start_time < filter_end 的类型不匹配错误
- 更新 mcp_ical/models.py 确保日期类型一致性

🤖 Generated with [Claude Code](https://claude.com/claude-code)